### PR TITLE
update to modelinterface v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.1.2
+- Adapt to `twinn-ml-interface v0.2.7`.
+- Only allow returning `list[DataLabelConfigTemplate]` in interface method `get_data_config_template`.
+
 ## Version 0.1.1
 - Implement changes from `ModelInterfaceV4` Version 0.2.4 (add `Configuration` and `MetaDataLogger` to `load` method)
 

--- a/README.md
+++ b/README.md
@@ -116,26 +116,31 @@ Next let's look at the `get_data_config_template()` method, which determines wha
 
 ```python
 @staticmethod
-def get_data_config_template() -> list[DataLabelConfigTemplate] | list[UnitTag]:
+def get_data_config_template() -> list[DataLabelConfigTemplate]:
     return [
-        UnitTag.from_string("altenburg1:discharge"),
-        UnitTag.from_string("eschweiler:discharge"),
-        UnitTag.from_string("herzogenrath1:discharge"),
-        UnitTag.from_string("juelich:discharge"),
-        UnitTag.from_string("stah:discharge"),
-        UnitTag.from_string("evap:evaporation"),
-        UnitTag.from_string("middenroer:precipitation"),
-        UnitTag.from_string("urft:precipitation"),
+        DataLabelConfigTemplate(
+            data_level=DataLevel.SENSOR,
+            unit_tag_templates=[
+                UnitTag.from_string("altenburg1:disc"),
+                UnitTag.from_string("eschweiler:disc"),
+                UnitTag.from_string("herzogenrath1:disc"),
+                UnitTag.from_string("juelich:disc"),
+                UnitTag.from_string("stah:disc"),
+                UnitTag.from_string("evap:evap"),
+                UnitTag.from_string("middenroer:prec"),
+                UnitTag.from_string("urft:prec"),
+            ],
+        ),
     ]
 ```
 
-There are again two possible implementations, either with `list[DataLabelConfigTemplate]` or `list[UnitTag]`. For illustration purposes we will show both. `UnitTag`, as used in the implementation above, we have already seen in the previous method. However, there is an alternative way to implement it, using the `from_string` class method, where we specify only the `unit_tag`, which is a combination between `unit_code` and `tag`, separated by a colon: `"{unit_code}:{tag}"`.
+There are again two possible implementations, both with `list[DataLabelConfigTemplate]` as output. For illustration purposes we will show both. In the first (shown above) a list of `UnitTag` objects, is passed to the `unit_tag_templates` attribute. We have seen this in the previous method, but there is an alternative way to implement it, using the `from_string` class method. We specify only the `unit_tag`, which is a combination between `unit_code` and `tag`, separated by a colon: `"{unit_code}:{tag}"`. Note that `DataLevel` is assigned arbitrarily as `SENSOR` for now - once it becomes clear what data we handle within the `DARROW` project we can update this.
 
-In the below implementation we use `DataLabelConfigTemplate` instead of `UnitTag`. This implementation is more complex, but takes advantage of relative paths in our __rooted tree__. The first `DataLabelConfigTemplate` selects all units following the path `RelativeType.PARENTS --> RelativeType.CHILDREN` starting from the _target_ unit. In this case, we select all units on the same level as the target. We need two entries of `DataLabelConfigTemplate`, because the first has datalevel `SENSOR`, while the second has datalevel `WEATHER`. A `DataLevel` distinction is made, because datalevels can have different properties when retrieving the data. This is not obvious when loading the data into your model, but does matter for the backend / data retrieval process. It is probably best to check with RHDHV which datalevels you should use for which data source.
+In the below implementation we use `UnitTagTemplate` instead of `UnitTag`. This implementation is more complex, but takes advantage of relative paths in our __rooted tree__. The first `DataLabelConfigTemplate` selects all units following the path `RelativeType.PARENTS --> RelativeType.CHILDREN` starting from the _target_ unit. In this case, we select all units on the same level as the target. We need two entries of `DataLabelConfigTemplate`, because the first has datalevel `SENSOR`, while the second has datalevel `WEATHER`. A `DataLevel` distinction is made, because datalevels can have different properties when retrieving the data. This is not obvious when loading the data into your model, but does matter for the backend / data retrieval process. It is probably best to check with RHDHV which datalevels you should use for which data source.
 
 ```python
 @staticmethod
-def get_data_config_template() -> list[DataLabelConfigTemplate] | list[UnitTag]:
+def get_data_config_template() -> list[DataLabelConfigTemplate]:
     return [
         DataLabelConfigTemplate(
             data_level=DataLevel.SENSOR,

--- a/darrow_poc/_version.py
+++ b/darrow_poc/_version.py
@@ -1,3 +1,3 @@
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
-__dev_version__ = "0.1.1"
+__dev_version__ = "0.1.2.dev0"

--- a/darrow_poc/models/poc.py
+++ b/darrow_poc/models/poc.py
@@ -49,7 +49,7 @@ class POCAnomaly:
         return UnitTag(Unit("STAH", "DISCHARGE_STATION", True), Tag("DISCHARGE"))
 
     @staticmethod
-    def get_data_config_template() -> list[DataLabelConfigTemplate] | list[UnitTag]:
+    def get_data_config_template() -> list[DataLabelConfigTemplate]:
         """The specification of data needed to train and predict with the model.
 
         NOTE:
@@ -58,18 +58,23 @@ class POCAnomaly:
         but requires you to know the exact units necessary for the model.
 
         Result:
-            list[DataLabelConfigTemplate] | list[UnitTag]: The data needed to train and predict with the model,
-                either as template or as list of literals.
+            list[DataLabelConfigTemplate]: The data needed to train and predict with the model,
+                either as template.
         """
         return [
-            UnitTag.from_string("altenburg1:disc"),
-            UnitTag.from_string("eschweiler:disc"),
-            UnitTag.from_string("herzogenrath1:disc"),
-            UnitTag.from_string("juelich:disc"),
-            UnitTag.from_string("stah:disc"),
-            UnitTag.from_string("evap:evap"),
-            UnitTag.from_string("middenroer:prec"),
-            UnitTag.from_string("urft:prec"),
+            DataLabelConfigTemplate(
+                data_level=DataLevel.SENSOR,
+                unit_tag_templates=[
+                    UnitTag.from_string("altenburg1:disc"),
+                    UnitTag.from_string("eschweiler:disc"),
+                    UnitTag.from_string("herzogenrath1:disc"),
+                    UnitTag.from_string("juelich:disc"),
+                    UnitTag.from_string("stah:disc"),
+                    UnitTag.from_string("evap:evap"),
+                    UnitTag.from_string("middenroer:prec"),
+                    UnitTag.from_string("urft:prec"),
+                ],
+            ),
         ]
 
     @staticmethod


### PR DESCRIPTION
- Adapt to `twinn-ml-interface v0.2.7`.
- Only allow returning `list[DataLabelConfigTemplate]` in interface method `get_data_config_template`.
