### PR TITLE
Bugfix/add datetime to predictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.1.7
 - add linting and testing github actions pipeline `validate_pipeline.yml`.
+- bugfix: Add datetime index to predictions dataframe.
 
 ## Version 0.1.6
 - Added github action pipelines for publishing to `testpypi` and `pypi`.

--- a/darrow_poc/_version.py
+++ b/darrow_poc/_version.py
@@ -1,3 +1,3 @@
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 
-__dev_version__ = "0.1.6.dev0"
+__dev_version__ = "0.1.7.dev0"

--- a/darrow_poc/models/poc.py
+++ b/darrow_poc/models/poc.py
@@ -194,7 +194,7 @@ class POCAnomaly:
         predictions = model.predict(X, target_channel)
         anomalies = get_anomalies(predictions, X, target_channel)
 
-        return [pd.DataFrame({target_channel: anomalies})], None
+        return [pd.DataFrame({target_channel: anomalies}, index=X.index)], None
 
     def dump(self, foldername: PathLike, filename: str) -> None:
         """


### PR DESCRIPTION
- add linting and testing github actions pipeline `validate_pipeline.yml`.
- bugfix: Add datetime index to predictions dataframe.
